### PR TITLE
Feature #10  기본 라우팅 세팅

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
+import { Outlet } from "react-router-dom";
+
 function App() {
-  return <div>HOME</div>;
+  return <Outlet />;
 }
 
 export default App;

--- a/src/layout/AuthLayout.tsx
+++ b/src/layout/AuthLayout.tsx
@@ -1,0 +1,10 @@
+import { Navigate, Outlet } from "react-router-dom";
+import ROUTE_PATH from "../router/constants";
+
+const AuthLayout = () => {
+  if (!localStorage.getItem("token")) return <Navigate to={ROUTE_PATH.INTRO} />;
+
+  return <Outlet />;
+};
+
+export default AuthLayout;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { RouterProvider } from "react-router-dom";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+import router from "./router";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+    <RouterProvider router={router} />
+  </React.StrictMode>
+);

--- a/src/pages/ErrorPage/index.tsx
+++ b/src/pages/ErrorPage/index.tsx
@@ -1,0 +1,5 @@
+const ErrorPage = () => {
+  return <h2>ErrorPage</h2>;
+};
+
+export default ErrorPage;

--- a/src/pages/IntroPage/index.tsx
+++ b/src/pages/IntroPage/index.tsx
@@ -1,0 +1,5 @@
+const IntroPage = () => {
+  return <div>Intro</div>;
+};
+
+export default IntroPage;

--- a/src/pages/KakaoLogInPage/index.tsx
+++ b/src/pages/KakaoLogInPage/index.tsx
@@ -1,0 +1,5 @@
+const KakaoLogIn = () => {
+  return <div>카카오 로그인</div>;
+};
+
+export default KakaoLogIn;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,0 +1,3 @@
+export { default as ErrorPage } from "./ErrorPage";
+export { default as IntroPage } from "./IntroPage";
+export { default as KakaoLogInPage } from "./KakaoLogInPage";

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -1,0 +1,7 @@
+const ROUTE_PATH = {
+  ROOT: "/",
+  INTRO: "/intro",
+  KAKAO_LOGIN: "/oauth/kakao/callback",
+} as const;
+
+export default ROUTE_PATH;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter } from "react-router-dom";
 import App from "../App";
 import ROUTE_PATH from "./constants";
 import { ErrorPage, IntroPage, KakaoLogInPage } from "../pages";
+import AuthLayout from "../layout/AuthLayout";
 
 const router = createBrowserRouter([
   {
@@ -18,6 +19,7 @@ const router = createBrowserRouter([
         element: <KakaoLogInPage />,
         path: ROUTE_PATH.KAKAO_LOGIN,
       },
+      { path: ROUTE_PATH.ROOT, element: <AuthLayout /> },
     ],
   },
 ]);

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,0 +1,25 @@
+import { createBrowserRouter } from "react-router-dom";
+
+import App from "../App";
+import ROUTE_PATH from "./constants";
+import { ErrorPage, IntroPage, KakaoLogInPage } from "../pages";
+
+const router = createBrowserRouter([
+  {
+    element: <App />,
+    errorElement: <ErrorPage />,
+    path: ROUTE_PATH.ROOT,
+    children: [
+      {
+        element: <IntroPage />,
+        path: ROUTE_PATH.INTRO,
+      },
+      {
+        element: <KakaoLogInPage />,
+        path: ROUTE_PATH.KAKAO_LOGIN,
+      },
+    ],
+  },
+]);
+
+export default router;


### PR DESCRIPTION
### 관련 문서

<!--이슈 링크-->
<!--Closes 뒤에 본 PR을 머지하면 close할 issue number를 적어주세요.-->

Closes #10 

### 변경사항:

<!--중요 커밋은 링크로 연결해서 추가-->
- 기본적인 라우팅 세팅을 진행했습니다.
    - router폴더 내의 constant ROUTE_PATH는 라우팅할 path 상수입니다.
- 기본 페이지를 intro페이지로 두기 위해 layout 을 설정해두었습니다.

### 확인할 목록:

<!--리뷰어에게 부탁할 확인 목록 및 테스트 방법을 작성-->
